### PR TITLE
Add "The Human in the Loop" article to RWL list

### DIFF
--- a/src/lib/data-for-rwl.js
+++ b/src/lib/data-for-rwl.js
@@ -9,6 +9,12 @@
 // };
 const DataList = [
   {
+    url: "https://adventures.nodeland.dev/archive/the-human-in-the-loop/?utm_source=lambrospetrou_com&utm_medium=read_watch_listen_page&utm_campaign=rwl",
+    title: "The Human in the Loop",
+    author: "Matteo Collina",
+    dateListed: "2026-02-01T12:00:00.000Z",
+  },
+  {
     url: "https://lethain.com/everyinc-compound-engineering/?utm_source=lambrospetrou_com&utm_medium=read_watch_listen_page&utm_campaign=rwl",
     title: "Learning from Every's Compound Engineering",
     author: "Will Larson",


### PR DESCRIPTION
## Summary
Added a new article entry to the Read, Watch, Listen (RWL) data list.

## Changes
- Added "The Human in the Loop" by Matteo Collina from adventures.nodeland.dev to the DataList
- Entry includes proper UTM tracking parameters for source attribution
- Dated February 1, 2026

## Details
The new entry follows the existing data structure with:
- Full URL with UTM parameters for analytics tracking
- Article title and author information
- ISO8601 formatted date for RSS feed compatibility

https://claude.ai/code/session_013xfCpExLrPPNKPcL6HCa6a