### PR TITLE
Add Patrick McKenzie's career advice article to reading list

### DIFF
--- a/src/lib/data-for-rwl.js
+++ b/src/lib/data-for-rwl.js
@@ -13,7 +13,7 @@ const DataList = [
     url: "https://www.kalzumeus.com/2011/10/28/dont-call-yourself-a-programmer/?utm_source=lambrospetrou_com&utm_medium=read_watch_listen_page&utm_campaign=rwl",
     title: "Don't Call Yourself A Programmer, And Other Career Advice",
     author: "Patrick McKenzie (patio11)",
-    dateListed: "2026-02-17T12:00:00.000Z",
+    dateListed: "2026-02-17T08:00:00.000Z",
   },
   {
     url: "https://alexharri.com/blog/ascii-rendering?utm_source=lambrospetrou_com&utm_medium=read_watch_listen_page&utm_campaign=rwl",

--- a/src/lib/data-for-rwl.js
+++ b/src/lib/data-for-rwl.js
@@ -10,6 +10,12 @@
 const DataList = [
 
   {
+    url: "https://www.kalzumeus.com/2011/10/28/dont-call-yourself-a-programmer/?utm_source=lambrospetrou_com&utm_medium=read_watch_listen_page&utm_campaign=rwl",
+    title: "Don't Call Yourself A Programmer, And Other Career Advice",
+    author: "Patrick McKenzie (patio11)",
+    dateListed: "2026-02-17T12:00:00.000Z",
+  },
+  {
     url: "https://alexharri.com/blog/ascii-rendering?utm_source=lambrospetrou_com&utm_medium=read_watch_listen_page&utm_campaign=rwl",
     title: "ASCII characters are not pixels: a deep dive into ASCII rendering",
     author: "Alex Harri",


### PR DESCRIPTION
## Summary
Added a new article entry to the "Read, Watch, Listen" data list.

## Changes
- Added entry for "Don't Call Yourself A Programmer, And Other Career Advice" by Patrick McKenzie (patio11)
- Article is positioned at the top of the DataList array
- Includes properly formatted metadata: URL with tracking parameters, title, author, and date listed (2026-02-17)

## Details
This article is a well-known resource in the programming community covering career development and professional growth advice. The entry follows the existing data structure with all required fields populated.

https://claude.ai/code/session_017orezTC43yk67TFDuXL8ds